### PR TITLE
Fix border in search icon

### DIFF
--- a/src/styles/components/_button.scss
+++ b/src/styles/components/_button.scss
@@ -23,6 +23,7 @@
     background: white;
     border: 1px solid #dedfe0;
     border-left: none;
+    border-radius: 0px;
 }
 
 .button--link {


### PR DESCRIPTION
I set the border radius to zero in order to avoid the rounding of the magnifying glass' border.
This is my approach for fixing #14 

Thanks for considering, :smile: